### PR TITLE
Blender 2.79: Set default values for Diffuse and Specular

### DIFF
--- a/o3d_io/io_o3d_import.py
+++ b/o3d_io/io_o3d_import.py
@@ -541,8 +541,9 @@ def generate_materials(cfg_materials, cfg_file_path, mat_counter, materials, mes
         if bpy.app.version < (2, 80):
             mat = mat_blender
             mat.diffuse_color = (diffuse_r, diffuse_g, diffuse_b)
+            mat.diffuse_intensity = 1
             mat.specular_hardness = spec_h
-            mat.specular_intensity = 1
+            mat.specular_intensity = 0
             mat.specular_color = (spec_r, spec_g, spec_b)
             mat.emit = np.mean(np.array(matl[2]) / np.max((np.array(matl[0][:3]), np.repeat(0.0001, 3)), axis=0))
         else:


### PR DESCRIPTION
Diffuse = 1 --> Default diffuse value changed to 1 so that the diffuse is controlled via the colour picker by default
Specular = 0 --> Specular value set to 0, as usually no specular is required, but this is active by default

Is it possible to read the diffuse and specular values directly from the o3d instead of using hardcoded values?